### PR TITLE
change entity and event listener to dash-case

### DIFF
--- a/lib/commands/create/event-listener.js
+++ b/lib/commands/create/event-listener.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const camelcase = require('lodash.camelcase');
-
 const eventListenerTemplate = require('../../templates/event-listener');
 const eventListenerFs = require('../../fs/event-listener');
 
@@ -35,16 +33,14 @@ const getPrompts = () => {
 		{
 			name: 'entity',
 			type: 'text',
-			message: 'What\'s the event entity?',
-			validate: notEmpty,
-			format: entity => camelcase(entity.trim())
+			message: 'What\'s the event entity? (in-dash-case)',
+			validate: /* istanbul ignore next */ notEmpty && (value => !!value.match(/^[a-z0-9-]+$/))
 		},
 		{
 			name: 'event',
 			type: 'text',
-			message: 'What\'s the event name?',
-			validate: notEmpty,
-			format: event => camelcase(event.trim())
+			message: 'What\'s the event name?  (in-dash-case)',
+			validate: /* istanbul ignore next */ notEmpty && (value => !!value.match(/^[a-z0-9-]+$/))
 		},
 		{
 			name: 'mustHaveClient',


### PR DESCRIPTION
Mejoras al crear un `event-listener`, ahora se crea en `dash-case`, en vez de `camelCase`